### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "~1.0"
+        "composer-plugin-api": "^1.0"
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",


### PR DESCRIPTION
Update composer-plugin-api this gets rid of the warning, and I was able to install a new version of Pyro just fine. Sorry it took so long!
