### PR TITLE
Fixed wrong RegEx

### DIFF
--- a/src/Installer/AddonInstaller.php
+++ b/src/Installer/AddonInstaller.php
@@ -46,7 +46,7 @@ class AddonInstaller extends LibraryInstaller
     {
         $types = $this->getTypes();
 
-        return "/^([a-zA-Z1-9-_]+)-({$types})$/";
+        return "/^([\w-]+)-({$types})$/";
     }
 
     /**


### PR DESCRIPTION
You know, `\w` is actually `[a-zA-Z0-9_]`.
So, `[\w-]` will be the same like `[a-zA-Z0-9-_]`.

Also, the situation with `1-9` against `0-9` is the typo, I am sure.
![image](https://user-images.githubusercontent.com/5930429/30001168-79c668fe-908e-11e7-8b35-8f17a50e8ae9.png)
